### PR TITLE
Bug/investigate bar30 temperature output

### DIFF
--- a/JAIA_BIO-PAYLOAD/Core/Inc/MS5837.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/MS5837.h
@@ -41,7 +41,7 @@ uint8_t getModel(void);
 void setFluidDensity(float density);
 
 float getPressure(float conversion);
-float getTemp(void);
+float getTemperature(void);
 float getAltitude(void);
 float getDepth(void);
 

--- a/JAIA_BIO-PAYLOAD/Core/Inc/MS5837.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/MS5837.h
@@ -25,7 +25,7 @@ typedef struct MS5837
   I2C_HandleTypeDef* pi2c;
   model_t model;
   int pressure;
-  int temp;
+  float temp;
 } sMS5837;
 
 // External Global Variables

--- a/JAIA_BIO-PAYLOAD/Core/Src/MS5837.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/MS5837.c
@@ -135,7 +135,7 @@ float getPressure(float conversion)
   }
 }
 
-float getTemp(void)
+float getTemperature(void)
 {
   return sDepth.temp/100.0f;
 }

--- a/JAIA_BIO-PAYLOAD/Core/Src/MS5837.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/MS5837.c
@@ -135,7 +135,7 @@ float getPressure(float conversion)
   }
 }
 
-float getTemperature(void)
+float getTemp(void)
 {
   return sDepth.temp/100.0f;
 }

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -187,6 +187,8 @@ int main(void)
       {
         bar30.has_pressure = true;
         bar30.pressure = getDepth();
+        bar30.has_temperature = true;
+        bar30.temperature = getTemp();
       }
 
       sensor_data.data.bar30 = bar30;

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -188,7 +188,7 @@ int main(void)
         bar30.has_pressure = true;
         bar30.pressure = getDepth();
         bar30.has_temperature = true;
-        bar30.temperature = getTemp();
+        bar30.temperature = getTemperature();
       }
 
       sensor_data.data.bar30 = bar30;


### PR DESCRIPTION
The temperature output was reading consistently in the billions. After investigation, we discovered that the getTemperature() function was declared in the pressure sensor header as getTemp() instead.