### PR TITLE
feature/deploy-to-stm32-without-debugger

### DIFF
--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -321,6 +321,10 @@ void process_sensor_request(SensorRequest *sensor_request)
       Sensors[jaiabot_sensor_protobuf_Sensor_BLUE_ROBOTICS__BAR30] = REQUESTED;
     }
   }
+  else if (sensor_request->has_mcu_command && sensor_request->mcu_command == jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE)
+  {
+    jumpToBootloader();
+  }
 }
 
 void transmit_sensor_data(SensorData *sensor_data)

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
@@ -11,6 +11,11 @@ import "jaiabot/messages/sensor/blue_robotics__bar30.proto";
 
 package jaiabot.sensor.protobuf;
 
+enum MCUCommand
+{
+    ENTER_BOOTLOADER_MODE = 1;
+}
+
 message SensorRequest
 {
     option (dccl.msg) = {
@@ -29,6 +34,8 @@ message SensorRequest
         // change name to VendorSensor format
         //  EchoCommand echo_command = 13;
     }
+
+    optional MCUCommand mcu_command = 20;
 }
 
 message SensorData
@@ -55,3 +62,8 @@ message SensorData
     }
 }
 
+message SensorThreadConfig
+{
+    optional Metadata metadata = 1;
+    optional int32 sample_rate = 2;
+}


### PR DESCRIPTION
### Summary
Calls `jumpToBootloader` when `ENTER_BOOTLOADER_MODE` command is received. This PR is paired with https://github.com/jaiarobotics/jaiabot/pull/1129.

### Testing
See: https://github.com/jaiarobotics/jaiabot/pull/1129

### Future Work
Where is the best location for the `mcu_command` to live in the `SensorRequest` message? When we have more time, this is something we will want to nail down.