### PR TITLE
bug/stm32-not-entering-bootloader-mode

### DIFF
--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -412,7 +412,8 @@ void process_sensor_request(SensorRequest *sensor_request)
       Sensors[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] = REQUESTED;
     }
   }
-  else if (sensor_request->has_mcu_command && sensor_request->mcu_command == jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE)
+
+  if (sensor_request->has_mcu_command && sensor_request->mcu_command == jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE)
   {
     jumpToBootloader();
   }

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -89,7 +89,7 @@ int Sensors[_jaiabot_sensor_protobuf_Sensor_ARRAYSIZE] = {0};
 // Sample rates expressed in milliseconds to match HAL_GetTick output
 int SensorSampleRates[_jaiabot_sensor_protobuf_Sensor_ARRAYSIZE] = {0};
 
-#define SOFTWARE_VERSION 2
+#define SOFTWARE_VERSION 3
 #define MAX_MSG_SIZE 256
 #define SENSOR_REQUEST_SAMPLE_RATE 1000
 #define MILLISECONDS_FACTOR 1000


### PR DESCRIPTION
### Summary
When a `mcu_command` was sent, it entered the block: `if (sensor_request->which_request_data == jaiabot_sensor_protobuf_SensorRequest_request_metadata_tag)` which prevented it from reaching the bootloader conditional.

### Testing
Successfully flashed STM32 from Raspberry Pi