### PR TITLE
Feature/calibrate bio sensors through stm32 for stm32

### DIFF
--- a/JAIA_BIO-PAYLOAD/Core/Inc/cfluor.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/cfluor.h
@@ -10,6 +10,7 @@ typedef struct CFluor
     float cal_coefficient;
     float concentration;
     float concentration_voltage;
+    float serial_number;
 } CFluor;
 
 extern CFluor sFluorometer;  
@@ -18,6 +19,7 @@ int readCFluor(void);
 void initCFluor(void);
 void set_CFluorOffset(float offset);
 void set_CFluorCalCoefficient(float cal_coefficient);
+void set_CFluorSerialNumber(float serial_number);
 float getConcentration(void);
 float convert_3_3_to_5_0(float voltage);
 float getConcentrationVoltage(void);

--- a/JAIA_BIO-PAYLOAD/Core/Inc/cfluor.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/cfluor.h
@@ -23,5 +23,8 @@ void set_CFluorSerialNumber(float serial_number);
 float getConcentration(void);
 float convert_3_3_to_5_0(float voltage);
 float getConcentrationVoltage(void);
+float getOffset(void);
+float getCalCoefficient(void);
+float getSerialNumber(void);
 
 #endif /* INC_CFluor_H_ */

--- a/JAIA_BIO-PAYLOAD/Core/Inc/main.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/main.h
@@ -114,7 +114,8 @@ void Error_Handler(void);
 #define PHASE_B_GPIO_Port GPIOB
 #define PPS_Pin GPIO_PIN_9
 #define PPS_GPIO_Port GPIOB
-#define PPS_EXTI_IRQn EXTI9_5_IRQn
+#define PPS_EXTI_IRQn EXTI9_5_IRQnA	*
+
 
 /* USER CODE BEGIN Private defines */
 

--- a/JAIA_BIO-PAYLOAD/Core/Inc/main.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/main.h
@@ -38,6 +38,7 @@ extern "C" {
 #include "cfluor.h"
 #include "math.h"
 
+#include <stdlib.h>
 #include <nanopb/pb_encode.h>
 #include <nanopb/pb_decode.h>
 

--- a/JAIA_BIO-PAYLOAD/Core/Inc/main.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/main.h
@@ -123,7 +123,9 @@ typedef enum SensorStates {
     INITIALIZED = 1,
     REQUESTED = 2,
     FAILED = 3,
+    STOPPED = 4,
 } SensorStates;
+
 typedef jaiabot_sensor_protobuf_Metadata Metadata;
 typedef jaiabot_sensor_protobuf_BlueRoboticsBar30 BlueRoboticsBar30;
 typedef jaiabot_sensor_protobuf_AtlasScientificOEMEC AtlasScientificOEMEC;

--- a/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
@@ -22,15 +22,15 @@
 /* EC Chip register addresses */
 typedef enum
 {
-    EC_OEM_DEV_TYPE = 0X00,
-    EC_OEM_FIRMWARE_VERSION = 0X01,
-    EC_OEM_ADDRESS_LOCK = 0X02,
-    EC_OEM_ADDRESS = 0X03,
-    EC_OEM_INTERRUPT_CTRL = 0X04,
-    EC_OEM_LED_CTRL = 0X05,
-    EC_OEM_ACTVATE_HIBERNATE = 0X06,
-    EC_OEM_NEW_READING_AVAILABLE = 0X07,
-    EC_OEM_PROBE_TYPE = 0X08,
+    EC_OEM_REG_DEV_TYPE = 0X00,
+    EC_OEM_REG_FIRMWARE_VERSION = 0X01,
+    EC_OEM_REG_ADDRESS_LOCK = 0X02,
+    EC_OEM_REG_ADDRESS = 0X03,
+    EC_OEM_REG_INTERRUPT_CTRL = 0X04,
+    EC_OEM_REG_LED_CTRL = 0X05,
+    EC_OEM_REG_ACTVATE_HIBERNATE = 0X06,
+    EC_OEM_REG_NEW_READING_AVAILABLE = 0X07,
+    EC_OEM_REG_PROBE_TYPE = 0X08,
     EC_OEM_REG_CAL = 0x0A,       // EC Calibration MSB (4 bytes wide, 0x0A-0x0D)
     EC_OEM_REG_CAL_REQ = 0x0E,   // EC Calibration Request (1 byte wide, 0x0E)
     EC_OEM_REG_CAL_CONF = 0x0F,  // EC Calibration Confirmation (1 byte wide, 0x0F)
@@ -55,8 +55,8 @@ typedef enum
     PH_OEM_REG_CAL = 0X08,
     PH_OEM_REG_CAL_REQ = 0X0C,
     PH_OEM_REG_CAL_CONF = 0X0D,
-    PH_OEM_TEMP_COMP = 0X0E,
-    PH_OEM_TEMP_CONF = 0X12,
+    PH_OEM_REG_TEMP_COMP = 0X0E,
+    PH_OEM_REG_TEMP_CONF = 0X12,
     PH_OEM_REG_PH = 0x16,
 } PH_Registers;
 
@@ -73,12 +73,12 @@ typedef enum
     DO_OEM_REG_NEW_READING_AVAILABLE = 0X07,
     DO_OEM_REG_CAL = 0X08,
     DO_OEM_REG_CAL_CONF = 0X09,
-    DO_OEM_SALINITY_COMP = 0X0A,
-    DO_OEM_PRESSURE_COMP = 0X0E,
-    DO_OEM_TEMP_COMP = 0X12,
-    DO_OEM_SALINITY_CONF = 0X16,
-    DO_OEM_PRESSURE_CONF = 0X1A,
-    DO_OEM_TEMP_CONF = 0X1E,
+    DO_OEM_REG_SALINITY_COMP = 0X0A,
+    DO_OEM_REG_PRESSURE_COMP = 0X0E,
+    DO_OEM_REG_TEMP_COMP = 0X12,
+    DO_OEM_REG_SALINITY_CONF = 0X16,
+    DO_OEM_REG_PRESSURE_CONF = 0X1A,
+    DO_OEM_REG_TEMP_CONF = 0X1E,
     DO_OEM_REG_DO = 0x22,
     DO_OEM_REG_DO_SAT = 0x26,
 } DO_Registers;
@@ -149,8 +149,13 @@ double getPHTemperatureVoltage();
 HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type);
 HAL_StatusTypeDef calibrateDO(uint8_t calibration_type);
 HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type);
-// HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev);
-// HAL_StatusTypeDef OEM_GetCalibration(OEM_CHIP *dev);
+HAL_StatusTypeDef clearCalibration(uint8_t sensor_type);
+HAL_StatusTypeDef setECTempCompensation(double compensation_value);
+HAL_StatusTypeDef setDOSalinityCompensation(double compensation_value);
+HAL_StatusTypeDef setDOPressureCompensation(double compensation_value);
+HAL_StatusTypeDef setDOTempCompensation(double compensation_value);
+HAL_StatusTypeDef setPHTempCompensation(double compensation_value);
+
 
 // /* LOW-LEVEL FUNCTIONS */
 HAL_StatusTypeDef OEM_ReadRegister(I2C_HandleTypeDef *i2cHandle, uint8_t devAddr, uint8_t reg, uint8_t *data);

--- a/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
@@ -109,6 +109,9 @@ double getDOTemperatureVoltage();
 double getPHTemperatureVoltage();
 
 // /* CALIBRATION */
+HAL_StatusTypeDef calibrateEC();
+HAL_StatusTypeDef calibrateDO();
+HAL_StatusTypeDef calibratePH();
 // HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev);
 // HAL_StatusTypeDef OEM_GetCalibration(OEM_CHIP *dev);
 

--- a/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
@@ -25,7 +25,7 @@ typedef enum
     EC_REG_OEM_DEV_TYPE = 0x04,  // EC device type
     EC_REG_OEM_CAL = 0x0A,       // EC Calibration MSB (4 bytes wide, 0x0A-0x0D)
     EC_REG_OEM_CAL_REQ = 0x0E,   // EC Calibration Request (1 byte wide, 0x0E)
-    EC_REG_OEM_CAL_CONF = 0x0F,  // EC Calibration Configuration (1 byte wide, 0x0F)
+    EC_REG_OEM_CAL_CONF = 0x0F,  // EC Calibration Confirmation (1 byte wide, 0x0F)
     EC_REG_OEM_TEMP_COMP = 0x10, // EC Temperature Compensation (4 bytes wide, 0x10-0x13)
     EC_REG_OEM_TEMP_CONF = 0x14, // EC Temperature Configuration (4 bytes wide, 0x14-0x17)
     EC_REG_OEM_EC = 0x18,        // EC Most Significant Byte (4 bytes wide, 0x18-0x1B)
@@ -57,6 +57,7 @@ typedef struct
     double conductivity;
     double total_dissolved_solids;
     double salinity;
+    uint8_t calibration_confirmation;
 } OEM_EC_CHIP;
 
 typedef struct
@@ -99,6 +100,7 @@ double OEM_ConvertVoltageToTemperature(double voltage);
 
 /* GETTERS */
 double getConductivity();
+uint8_t getEC_CalibrationConfirmation();
 double getTDS();
 double getSalinity();
 double getDO();
@@ -109,9 +111,9 @@ double getDOTemperatureVoltage();
 double getPHTemperatureVoltage();
 
 // /* CALIBRATION */
-HAL_StatusTypeDef calibrateEC();
-HAL_StatusTypeDef calibrateDO();
-HAL_StatusTypeDef calibratePH();
+HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type);
+HAL_StatusTypeDef calibrateDO(double calibration_value, uint8_t calibration_type);
+HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type);
 // HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev);
 // HAL_StatusTypeDef OEM_GetCalibration(OEM_CHIP *dev);
 
@@ -119,5 +121,6 @@ HAL_StatusTypeDef calibratePH();
 HAL_StatusTypeDef OEM_ReadRegister(I2C_HandleTypeDef *i2cHandle, uint8_t devAddr, uint8_t reg, uint8_t *data);
 HAL_StatusTypeDef OEM_ReadRegisters(I2C_HandleTypeDef *i2cHandle, uint8_t devAddr, uint8_t reg, uint8_t *data, uint8_t len);
 HAL_StatusTypeDef OEM_WriteRegister(I2C_HandleTypeDef *i2cHandle, uint8_t devAddr, uint8_t reg, uint8_t *data);
+HAL_StatusTypeDef OEM_WriteRegisters(I2C_HandleTypeDef *i2cHandle, uint8_t devAddr, uint8_t reg, uint8_t *data, uint8_t len);
 
 #endif

--- a/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
@@ -22,30 +22,65 @@
 /* EC Chip register addresses */
 typedef enum
 {
-    EC_REG_OEM_DEV_TYPE = 0x04,  // EC device type
-    EC_REG_OEM_CAL = 0x0A,       // EC Calibration MSB (4 bytes wide, 0x0A-0x0D)
-    EC_REG_OEM_CAL_REQ = 0x0E,   // EC Calibration Request (1 byte wide, 0x0E)
-    EC_REG_OEM_CAL_CONF = 0x0F,  // EC Calibration Confirmation (1 byte wide, 0x0F)
-    EC_REG_OEM_TEMP_COMP = 0x10, // EC Temperature Compensation (4 bytes wide, 0x10-0x13)
-    EC_REG_OEM_TEMP_CONF = 0x14, // EC Temperature Configuration (4 bytes wide, 0x14-0x17)
-    EC_REG_OEM_EC = 0x18,        // EC Most Significant Byte (4 bytes wide, 0x18-0x1B)
-    EC_REG_OEM_TDS = 0x1C,       // EC TDS (4 bytes wide, 0x1C-0x1F)
-    EC_REG_OEM_SALINITY = 0x20,  // EC Salinity (4 bytes wide, 0x20-0x23)
+    EC_OEM_DEV_TYPE = 0X00,
+    EC_OEM_FIRMWARE_VERSION = 0X01,
+    EC_OEM_ADDRESS_LOCK = 0X02,
+    EC_OEM_ADDRESS = 0X03,
+    EC_OEM_INTERRUPT_CTRL = 0X04,
+    EC_OEM_LED_CTRL = 0X05,
+    EC_OEM_ACTVATE_HIBERNATE = 0X06,
+    EC_OEM_NEW_READING_AVAILABLE = 0X07,
+    EC_OEM_PROBE_TYPE = 0X08,
+    EC_OEM_REG_CAL = 0x0A,       // EC Calibration MSB (4 bytes wide, 0x0A-0x0D)
+    EC_OEM_REG_CAL_REQ = 0x0E,   // EC Calibration Request (1 byte wide, 0x0E)
+    EC_OEM_REG_CAL_CONF = 0x0F,  // EC Calibration Confirmation (1 byte wide, 0x0F)
+    EC_OEM_REG_TEMP_COMP = 0x10, // EC Temperature Compensation (4 bytes wide, 0x10-0x13)
+    EC_OEM_REG_TEMP_CONF = 0x14, // EC Temperature Configuration (4 bytes wide, 0x14-0x17)
+    EC_OEM_REG_EC = 0x18,        // EC Most Significant Byte (4 bytes wide, 0x18-0x1B)
+    EC_OEM_REG_TDS = 0x1C,       // EC TDS (4 bytes wide, 0x1C-0x1F)
+    EC_OEM_REG_SALINITY = 0x20,  // EC Salinity (4 bytes wide, 0x20-0x23)
 } EC_Registers;
 
 /* pH Chip register addresses */
 typedef enum
 {
-    PH_REG_OEM_DEV_TYPE = 0x01,
-    PH_REG_OEM_PH = 0x16,
+    PH_OEM_REG_DEV_TYPE = 0x00,
+    PH_OEM_REG_DEV_VERSION = 0X01,
+    PH_OEM_REG_ADDRESS_LOCK = 0X02,
+    PH_OEM_REG_ADDRESS = 0X03,
+    PH_OEM_REG_INTERRUPT_CTRL = 0X04,
+    PH_OEM_REG_LED_CTRL = 0X05,
+    PH_OEM_REG_ACTVATE_HIBERNATE = 0X06,
+    PH_OEM_REG_NEW_READING_AVAILABLE = 0X07,
+    PH_OEM_REG_CAL = 0X08,
+    PH_OEM_REG_CAL_REQ = 0X0C,
+    PH_OEM_REG_CAL_CONF = 0X0D,
+    PH_OEM_TEMP_COMP = 0X0E,
+    PH_OEM_TEMP_CONF = 0X12,
+    PH_OEM_REG_PH = 0x16,
 } PH_Registers;
 
 /* DO Chip register addresses */
 typedef enum
 {
-    DO_REG_OEM_DEV_TYPE = 0x03,
-    DO_REG_OEM_DO = 0x22,
-    DO_REG_OEM_DO_SAT = 0x26,
+    DO_OEM_REG_DEV_TYPE = 0x00,
+    DO_OEM_REG_DEV_VERSION = 0X01,
+    DO_OEM_REG_ADDRESS_LOCK = 0X02,
+    DO_OEM_REG_ADDRESS = 0X03,
+    DO_OEM_REG_INTERRUPT_CTRL = 0X04,
+    DO_OEM_REG_LED_CTRL = 0X05,
+    DO_OEM_REG_ACTVATE_HIBERNATE = 0X06,
+    DO_OEM_REG_NEW_READING_AVAILABLE = 0X07,
+    DO_OEM_REG_CAL = 0X08,
+    DO_OEM_REG_CAL_CONF = 0X09,
+    DO_OEM_SALINITY_COMP = 0X0A,
+    DO_OEM_PRESSURE_COMP = 0X0E,
+    DO_OEM_TEMP_COMP = 0X12,
+    DO_OEM_SALINITY_CONF = 0X16,
+    DO_OEM_PRESSURE_CONF = 0X1A,
+    DO_OEM_TEMP_CONF = 0X1E,
+    DO_OEM_REG_DO = 0x22,
+    DO_OEM_REG_DO_SAT = 0x26,
 } DO_Registers;
 
 /* SENSOR STRUCT */
@@ -112,7 +147,7 @@ double getPHTemperatureVoltage();
 
 // /* CALIBRATION */
 HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type);
-HAL_StatusTypeDef calibrateDO(double calibration_value, uint8_t calibration_type);
+HAL_StatusTypeDef calibrateDO(uint8_t calibration_type);
 HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type);
 // HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev);
 // HAL_StatusTypeDef OEM_GetCalibration(OEM_CHIP *dev);

--- a/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
+++ b/JAIA_BIO-PAYLOAD/Core/Inc/oem_library.h
@@ -103,6 +103,7 @@ typedef struct
     double ph;
     double temperature;
     float temperature_voltage;
+    uint8_t calibration_confirmation;
 } OEM_PH_CHIP;
 
 typedef struct
@@ -113,6 +114,7 @@ typedef struct
     double dissolved_oxygen;
     double temperature;
     float temperature_voltage;
+    uint8_t calibration_confirmation;
 } OEM_DO_CHIP;
 
 extern OEM_EC_CHIP ec;

--- a/JAIA_BIO-PAYLOAD/Core/Src/cfluor.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/cfluor.c
@@ -45,3 +45,18 @@ float getConcentrationVoltage()
 {
     return sFluorometer.concentration_voltage;
 }
+
+float getOffset()
+{
+    return sFluorometer.offset;
+}
+
+float getCalCoefficient()
+{
+    return sFluorometer.cal_coefficient;
+}
+
+float getSerialNumber()
+{
+    return sFluorometer.serial_number;
+}

--- a/JAIA_BIO-PAYLOAD/Core/Src/cfluor.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/cfluor.c
@@ -31,6 +31,11 @@ void set_CFluorCalCoefficient(float cal_coefficient)
     sFluorometer.cal_coefficient = cal_coefficient;
 }
 
+void set_CFluorSerialNumber(float serial_number)
+{
+    sFluorometer.serial_number = serial_number;
+}
+
 float getConcentration()
 {
     return sFluorometer.concentration;

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -217,8 +217,8 @@ int main(void)
   
   // Hardcoded offset and cal coefficient for Turner CFluor 
   init_CFluor();
-  set_CFluorOffset(0.0318f);
-  set_CFluorCalCoefficient(29.7527f);
+  set_CFluorOffset(0.0997);
+  set_CFluorCalCoefficient(44.608f);
 
   // Must be called before computing CRC32
   init_crc32_table();
@@ -281,19 +281,19 @@ int main(void)
     if (Sensors[jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH] == REQUESTED && time >= ph_target_send_time)
     {
       ph_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH];
-      transmit_atlas_scientific_ph_data();
+      // transmit_atlas_scientific_ph_data();
     }
 
     if (Sensors[jaiabot_sensor_protobuf_Sensor_BLUE_ROBOTICS__BAR30] == REQUESTED && time >= bar30_target_send_time)
     {
       bar30_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_BLUE_ROBOTICS__BAR30];
-      transmit_blue_robotics_bar30_data();
+      // transmit_blue_robotics_bar30_data();
     }
 
     if (Sensors[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] == REQUESTED && time >= turner_c_fluor_target_send_time)
     {
       turner_c_fluor_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR];
-      transmit_turner_c_fluor_data();
+      // transmit_turner_c_fluor_data();
     }
 
     time = HAL_GetTick();
@@ -429,7 +429,7 @@ void process_sensor_request(SensorRequest *sensor_request)
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_EC);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_DRY:
-        calibrateEC(0.0, 2);
+        calibrateEC(0.000000, 2);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_LOW:
         calibrateEC(sensor_request->calibration_value * 100.0, 4);
@@ -441,22 +441,22 @@ void process_sensor_request(SensorRequest *sensor_request)
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_DO);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_LOW:
-        calibrateDO(sensor_request->calibration_value, 'LOW');
+        calibrateDO(3);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH:
-        calibrateDO(sensor_request->calibration_value, 'HIGH');
+        calibrateDO(2);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION:
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_LOW:
-        calibratePH(sensor_request->calibration_value, 'LOW');
+        calibratePH(sensor_request->calibration_value * 1000.0, 2);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_MID:
-        calibratePH(sensor_request->calibration_value, 'MID');
+        calibratePH(sensor_request->calibration_value * 1000.0, 3);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH:
-        calibratePH(sensor_request->calibration_value, 'HIGH');
+        calibratePH(sensor_request->calibration_value * 1000.0, 4);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION:
         stopCalibration();
@@ -469,8 +469,6 @@ void process_sensor_request(SensorRequest *sensor_request)
 
 void startCalibration(jaiabot_sensor_protobuf_Sensor sensor)
 {
-  printf("START CALIBRATION\r\n");
-  printf("SENSOR Calibrated: %d\r\n", sensor);
   for (int i = 0; i < _jaiabot_sensor_protobuf_Sensor_ARRAYSIZE; i++)
   {
     // Set all of our sensors to UNITIALIZED besides the one we're calibrating
@@ -592,7 +590,8 @@ void transmit_atlas_scientific_ec_data()
   }
 
   sensor_data.data.oem_ec = oem_ec;
-  transmit_sensor_data(&sensor_data);
+  printf("EC: %d\r\n", getConductivity());
+  // transmit_sensor_data(&sensor_data);
 }
 
 void transmit_atlas_scientific_do_data()
@@ -613,7 +612,8 @@ void transmit_atlas_scientific_do_data()
   }
 
   sensor_data.data.oem_do = oem_do;
-  transmit_sensor_data(&sensor_data);
+  printf("DO: %d\r\n", getDO());
+  // transmit_sensor_data(&sensor_data);
 }
 
 void transmit_atlas_scientific_ph_data()

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -417,6 +417,51 @@ void process_sensor_request(SensorRequest *sensor_request)
   {
     jumpToBootloader();
   }
+
+  if (sensor_request->has_calibration_command)
+  {
+    switch (sensor_request->calibration_command)
+    {
+      case jaiabot_sensor_protobuf_CalibrationCommand_START_EC_CALIBRATION:
+        startECCalibration();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_DRY:
+        calibrateECDry();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_LOW:
+        calibrateECLow();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_HIGH:
+        calibrateECHigh();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_START_PH_CALIBRATION:
+        startPHCalibration();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_LOW:
+        calibratePHLow();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_MID:
+        calibratePHMid();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_HIGH:
+        calibratePHHigh();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_START_DO_CALIBRATION:
+        startDOCalibration();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_LOW:
+        calibrateDOLow();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_HIGH:
+        calibrateDOHigh();
+        break;
+      case jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION:
+        stopCalibration();
+        break;
+      default:
+        break;
+    }
+  }
 }
 
 void transmit_sensor_data(SensorData *sensor_data)

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -412,6 +412,13 @@ void process_sensor_request(SensorRequest *sensor_request)
     {
       SensorSampleRates[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] = hz_to_ms(sensor_request->request_data.cfg.sample_freq);
       Sensors[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] = REQUESTED;
+
+      if (sensor_request->request_data.cfg.cfg->size() > 0)
+      {
+        set_CFluorOffset(atof(sensor_request->request_data.cfg.cfg[0].value));
+        set_CFluorCalCoefficient(atof(sensor_request->request_data.cfg.cfg[1].value));
+        set_CFluorSerialNumber(atof(sensor_request->request_data.cfg.cfg[2].value));
+      }
     }
   }
 

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -215,10 +215,7 @@ int main(void)
   init_atlas_scientific_pH();
   init_blue_robotics_bar30();
   
-  // Hardcoded offset and cal coefficient for Turner CFluor 
   init_CFluor();
-  set_CFluorOffset(0.0997);
-  set_CFluorCalCoefficient(44.608f);
 
   // Must be called before computing CRC32
   init_crc32_table();
@@ -413,7 +410,7 @@ void process_sensor_request(SensorRequest *sensor_request)
       SensorSampleRates[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] = hz_to_ms(sensor_request->request_data.cfg.sample_freq);
       Sensors[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] = REQUESTED;
 
-      if (sensor_request->request_data.cfg.cfg->size() > 0)
+      if (sensor_request->request_data.cfg.cfg_count > 0)
       {
         set_CFluorOffset(atof(sensor_request->request_data.cfg.cfg[0].value));
         set_CFluorCalCoefficient(atof(sensor_request->request_data.cfg.cfg[1].value));

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -281,19 +281,19 @@ int main(void)
     if (Sensors[jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH] == REQUESTED && time >= ph_target_send_time)
     {
       ph_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH];
-      // transmit_atlas_scientific_ph_data();
+      transmit_atlas_scientific_ph_data();
     }
 
     if (Sensors[jaiabot_sensor_protobuf_Sensor_BLUE_ROBOTICS__BAR30] == REQUESTED && time >= bar30_target_send_time)
     {
       bar30_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_BLUE_ROBOTICS__BAR30];
-      // transmit_blue_robotics_bar30_data();
+      transmit_blue_robotics_bar30_data();
     }
 
     if (Sensors[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR] == REQUESTED && time >= turner_c_fluor_target_send_time)
     {
       turner_c_fluor_target_send_time = time + SensorSampleRates[jaiabot_sensor_protobuf_Sensor_TURNER__C_FLUOR];
-      // transmit_turner_c_fluor_data();
+      transmit_turner_c_fluor_data();
     }
 
     time = HAL_GetTick();
@@ -437,6 +437,9 @@ void process_sensor_request(SensorRequest *sensor_request)
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_HIGH:
         calibrateEC(sensor_request->calibration_value * 100.0, 5);
         break;
+      case jaiabot_sensor_protobuf_CalibrationType_CLEAR_EC_CALIBRATION:
+        clearCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_EC);
+        break;
       case jaiabot_sensor_protobuf_CalibrationType_START_DO_CALIBRATION:
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_DO);
         break;
@@ -445,6 +448,9 @@ void process_sensor_request(SensorRequest *sensor_request)
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH:
         calibrateDO(2);
+        break;
+      case jaiabot_sensor_protobuf_CalibrationType_CLEAR_DO_CALIBRATION:
+        clearCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_DO);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION:
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH);
@@ -458,8 +464,35 @@ void process_sensor_request(SensorRequest *sensor_request)
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH:
         calibratePH(sensor_request->calibration_value * 1000.0, 4);
         break;
+      case jaiabot_sensor_protobuf_CalibrationType_CLEAR_PH_CALIBRATION:
+        clearCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH);
+        break;
       case jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION:
         stopCalibration();
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (sensor_request->has_compensation_type)
+  {
+    switch (sensor_request->compensation_type)
+    {
+      case jaiabot_sensor_protobuf_CompensationType_SET_EC_TEMPERATURE_COMPENSATION:
+        setECTempCompensation(sensor_request->compensation_value * 100.0);
+        break;
+      case jaiabot_sensor_protobuf_CompensationType_SET_DO_SALINITY_COMPENSATION:
+        setDOSalinityCompensation(sensor_request->compensation_value * 100.0);
+        break;
+      case jaiabot_sensor_protobuf_CompensationType_SET_DO_PRESSURE_COMPENSATION:
+        setDOPressureCompensation(sensor_request->compensation_value * 100.0);
+        break;
+      case jaiabot_sensor_protobuf_CompensationType_SET_DO_TEMPERATURE_COMPENSATION:
+        setDOTempCompensation(sensor_request->compensation_value * 100.0);
+        break;
+      case jaiabot_sensor_protobuf_CompensationType_SET_PH_TEMPERATURE_COMPENSATION:
+        setPHTempCompensation(sensor_request->compensation_value * 100.0);
         break;
       default:
         break;
@@ -590,8 +623,7 @@ void transmit_atlas_scientific_ec_data()
   }
 
   sensor_data.data.oem_ec = oem_ec;
-  printf("EC: %d\r\n", getConductivity());
-  // transmit_sensor_data(&sensor_data);
+  transmit_sensor_data(&sensor_data);
 }
 
 void transmit_atlas_scientific_do_data()
@@ -612,8 +644,7 @@ void transmit_atlas_scientific_do_data()
   }
 
   sensor_data.data.oem_do = oem_do;
-  printf("DO: %d\r\n", getDO());
-  // transmit_sensor_data(&sensor_data);
+  transmit_sensor_data(&sensor_data);
 }
 
 void transmit_atlas_scientific_ph_data()

--- a/JAIA_BIO-PAYLOAD/Core/Src/main.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/main.c
@@ -429,34 +429,34 @@ void process_sensor_request(SensorRequest *sensor_request)
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_EC);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_DRY:
-        calibrateEC('DRY');
+        calibrateEC(0.0, 2);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_LOW:
-        calibrateEC('LOW');
+        calibrateEC(sensor_request->calibration_value * 100.0, 4);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_HIGH:
-        calibrateEC('HIGH');
+        calibrateEC(sensor_request->calibration_value * 100.0, 5);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_START_DO_CALIBRATION:
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_DO);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_LOW:
-        calibrateDO('LOW');
+        calibrateDO(sensor_request->calibration_value, 'LOW');
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH:
-        calibrateDO('HIGH');
+        calibrateDO(sensor_request->calibration_value, 'HIGH');
         break;
       case jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION:
         startCalibration(jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH);
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_LOW:
-        calibratePH('LOW');
+        calibratePH(sensor_request->calibration_value, 'LOW');
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_MID:
-        calibratePH('MID');
+        calibratePH(sensor_request->calibration_value, 'MID');
         break;
       case jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH:
-        calibratePH('HIGH');
+        calibratePH(sensor_request->calibration_value, 'HIGH');
         break;
       case jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION:
         stopCalibration();

--- a/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
@@ -154,6 +154,20 @@ double getPHTemperatureVoltage() { return ph.temperature_voltage; }
  * CALIBRATION DATA
  */
 
+HAL_StatusTypeDef calibrateEC() {
+  return 0;
+}
+
+HAL_StatusTypeDef calibrateDO() {
+  return 0;
+}
+
+HAL_StatusTypeDef calibratePH() {
+  return 0;
+}
+
+
+
 // HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev) {
 //     return
 // }

--- a/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
@@ -180,14 +180,6 @@ HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type
     return status;
   }
 
-  uint8_t regData[4];
-  status = OEM_ReadRegisters(ec.i2cHandle, ec.devAddr, EC_OEM_REG_CAL, &regData[0], 4);
-  if (status != HAL_OK) {
-    return status;
-  }
-
-  printf("Calibration confirmation: %02X %02X %02X %02X\r\n", regData[0], regData[1], regData[2], regData[3]);
-
   return status;
 }
 
@@ -199,21 +191,13 @@ HAL_StatusTypeDef calibrateDO(uint8_t calibration_type) {
     return status;
   }
 
-  uint8_t regData;
-  status = OEM_ReadRegister(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_CAL_CONF, &regData);
-  if (status != HAL_OK) {
-    return status;
-  }
-
-  printf("Calibration confirmation: %02X\r\n", regData);
-
   return status;
 }
 
 HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type) {
   HAL_StatusTypeDef status;
 
-  // Convert calibearion value from double to uint32_t (hex)
+  // Convert calibration value from double to uint32_t (hex)
   uint32_t calibration_value_hex = (uint32_t)calibration_value;
 
   // Reverse the byte order of the calibration value
@@ -233,26 +217,110 @@ HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type
     return status;
   }
 
-  uint8_t regData[4];
-  status = OEM_ReadRegisters(ph.i2cHandle, ph.devAddr, PH_OEM_REG_CAL, &regData[0], 4);
-  if (status != HAL_OK) {
-    return status;
-  }
-
-  printf("Calibration confirmation: %02X %02X %02X %02X\r\n", regData[0], regData[1], regData[2], regData[3]);
-
   return status;
 }
 
+HAL_StatusTypeDef clearCalibration(uint8_t sensor_type) {
+  HAL_StatusTypeDef status;
+  uint8_t clear_calibration_command = 0x01;
 
+  switch (sensor_type) {
+    case jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_EC:
+      status = OEM_WriteRegister(ec.i2cHandle, ec.devAddr, EC_OEM_REG_CAL_REQ, &clear_calibration_command);
+      break;
+    case jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_DO:
+      status = OEM_WriteRegister(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_CAL, &clear_calibration_command);
+      break;
+    case jaiabot_sensor_protobuf_Sensor_ATLAS_SCIENTIFIC__OEM_PH:
+      status = OEM_WriteRegister(ph.i2cHandle, ph.devAddr, PH_OEM_REG_CAL_REQ, &clear_calibration_command);
+      break;
+    default:
+      return HAL_ERROR;
+  }
+  
+  return status;
+}
 
-// HAL_StatusTypeDef OEM_SetCalibration(OEM_CHIP *dev) {
-//     return
-// }
+HAL_StatusTypeDef setECTempCompensation(double compensation_value) {
+  // Convert compensation value from double to uint32_t (hex)
+  uint32_t compensation_value_hex = (uint32_t)compensation_value;
 
-// HAL_StatusTypeDef OEM_GetCalibration(OEM_CHIP *dev) {
-//     return
-// }
+  // Reverse the byte order of the compensation value
+  uint8_t compensation_value_bytes[4];
+  compensation_value_bytes[0] = (compensation_value_hex >> 24) & 0xFF;
+  compensation_value_bytes[1] = (compensation_value_hex >> 16) & 0xFF;
+  compensation_value_bytes[2] = (compensation_value_hex >> 8) & 0xFF;
+  compensation_value_bytes[3] = compensation_value_hex & 0xFF;
+
+  HAL_StatusTypeDef status = OEM_WriteRegisters(ec.i2cHandle, ec.devAddr, EC_OEM_REG_TEMP_COMP, compensation_value_bytes, 4);
+  
+  return status;
+}
+
+HAL_StatusTypeDef setDOSalinityCompensation(double compensation_value) {
+  // Convert compensation value from double to uint32_t (hex)
+  uint32_t compensation_value_hex = (uint32_t)compensation_value;
+
+  // Reverse the byte order of the compensation value
+  uint8_t compensation_value_bytes[4];
+  compensation_value_bytes[0] = (compensation_value_hex >> 24) & 0xFF;
+  compensation_value_bytes[1] = (compensation_value_hex >> 16) & 0xFF;
+  compensation_value_bytes[2] = (compensation_value_hex >> 8) & 0xFF;
+  compensation_value_bytes[3] = compensation_value_hex & 0xFF;
+
+  HAL_StatusTypeDef status = OEM_WriteRegisters(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_SALINITY_COMP, compensation_value_bytes, 4);
+  
+  return status;
+}
+
+HAL_StatusTypeDef setDOPressureCompensation(double compensation_value) {
+  // Convert compensation value from double to uint32_t (hex)
+  uint32_t compensation_value_hex = (uint32_t)compensation_value;
+
+  // Reverse the byte order of the compensation value
+  uint8_t compensation_value_bytes[4];
+  compensation_value_bytes[0] = (compensation_value_hex >> 24) & 0xFF;
+  compensation_value_bytes[1] = (compensation_value_hex >> 16) & 0xFF;
+  compensation_value_bytes[2] = (compensation_value_hex >> 8) & 0xFF;
+  compensation_value_bytes[3] = compensation_value_hex & 0xFF;
+
+  HAL_StatusTypeDef status = OEM_WriteRegisters(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_PRESSURE_COMP, compensation_value_bytes, 4);
+  
+  return status;
+}
+
+HAL_StatusTypeDef setDOTempCompensation(double compensation_value) {
+  // Convert compensation value from double to uint32_t (hex)
+  uint32_t compensation_value_hex = (uint32_t)compensation_value;
+
+  // Reverse the byte order of the compensation value
+  uint8_t compensation_value_bytes[4];
+  compensation_value_bytes[0] = (compensation_value_hex >> 24) & 0xFF;
+  compensation_value_bytes[1] = (compensation_value_hex >> 16) & 0xFF;
+  compensation_value_bytes[2] = (compensation_value_hex >> 8) & 0xFF;
+  compensation_value_bytes[3] = compensation_value_hex & 0xFF;
+
+  HAL_StatusTypeDef status = OEM_WriteRegisters(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_TEMP_COMP, compensation_value_bytes, 4);
+  
+  return status;
+}
+
+HAL_StatusTypeDef setPHTempCompensation(double compensation_value) {
+  
+  // Convert compensation value from double to uint32_t (hex)
+  uint32_t compensation_value_hex = (uint32_t)compensation_value;
+
+  // Reverse the byte order of the compensation value
+  uint8_t compensation_value_bytes[4];
+  compensation_value_bytes[0] = (compensation_value_hex >> 24) & 0xFF;
+  compensation_value_bytes[1] = (compensation_value_hex >> 16) & 0xFF;
+  compensation_value_bytes[2] = (compensation_value_hex >> 8) & 0xFF;
+  compensation_value_bytes[3] = compensation_value_hex & 0xFF;
+
+  HAL_StatusTypeDef status = OEM_WriteRegisters(ph.i2cHandle, ph.devAddr, PH_OEM_REG_TEMP_COMP, compensation_value_bytes, 4);
+  
+  return status;
+}
 
 
 /* LOW-LEVEL FUNCTIONS */

--- a/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
@@ -180,6 +180,9 @@ HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type
     return status;
   }
 
+  // Delay to allow calibration confirmation register to be updated
+  HAL_Delay(1000);
+
   status = OEM_ReadRegister(ec.i2cHandle, ec.devAddr, EC_OEM_REG_CAL_CONF, &ec.calibration_confirmation);
   if (status != HAL_OK) {
     return status;
@@ -195,6 +198,9 @@ HAL_StatusTypeDef calibrateDO(uint8_t calibration_type) {
   if (status != HAL_OK) {
     return status;
   }
+
+  // Delay to allow calibration confirmation register to be updated
+  HAL_Delay(1000);
 
   status = OEM_ReadRegister(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_CAL_CONF, &dOxy.calibration_confirmation);
   if (status != HAL_OK) {
@@ -226,6 +232,9 @@ HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type
   if (status != HAL_OK) {
     return status;
   }
+
+  // Delay to allow calibration confirmation register to be updated
+  HAL_Delay(1000);
 
   status = OEM_ReadRegister(ph.i2cHandle, ph.devAddr, PH_OEM_REG_CAL_CONF, &ph.calibration_confirmation);
   if (status != HAL_OK) {

--- a/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
+++ b/JAIA_BIO-PAYLOAD/Core/Src/oem_library.c
@@ -121,7 +121,7 @@ HAL_StatusTypeDef get_PHReading()
   uint8_t regData[4];
   float divFactor = 1000.0f;
   HAL_StatusTypeDef status = HAL_OK;
-
+ 
   // pH
   status = OEM_ReadRegisters(ph.i2cHandle, ph.devAddr, PH_OEM_REG_PH, &regData[0], 4);
   uint32_t regReading = (regData[0] << 24) | (regData[1] << 16) | (regData[2] << 8) | regData[3];
@@ -180,6 +180,11 @@ HAL_StatusTypeDef calibrateEC(double calibration_value, uint8_t calibration_type
     return status;
   }
 
+  status = OEM_ReadRegister(ec.i2cHandle, ec.devAddr, EC_OEM_REG_CAL_CONF, &ec.calibration_confirmation);
+  if (status != HAL_OK) {
+    return status;
+  }
+
   return status;
 }
 
@@ -187,6 +192,11 @@ HAL_StatusTypeDef calibrateDO(uint8_t calibration_type) {
   HAL_StatusTypeDef status;
 
   status = OEM_WriteRegister(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_CAL, &calibration_type);
+  if (status != HAL_OK) {
+    return status;
+  }
+
+  status = OEM_ReadRegister(dOxy.i2cHandle, dOxy.devAddr, DO_OEM_REG_CAL_CONF, &dOxy.calibration_confirmation);
   if (status != HAL_OK) {
     return status;
   }
@@ -213,6 +223,11 @@ HAL_StatusTypeDef calibratePH(double calibration_value, uint8_t calibration_type
   }
 
   status = OEM_WriteRegister(ph.i2cHandle, ph.devAddr, PH_OEM_REG_CAL_REQ, &calibration_type);
+  if (status != HAL_OK) {
+    return status;
+  }
+
+  status = OEM_ReadRegister(ph.i2cHandle, ph.devAddr, PH_OEM_REG_CAL_CONF, &ph.calibration_confirmation);
   if (status != HAL_OK) {
     return status;
   }

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.c
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.c
@@ -9,21 +9,10 @@
 PB_BIND(jaiabot_sensor_protobuf_Metadata, jaiabot_sensor_protobuf_Metadata, 2)
 
 
-PB_BIND(jaiabot_sensor_protobuf_Metadata_Calibration, jaiabot_sensor_protobuf_Metadata_Calibration, 2)
-
-
-PB_BIND(jaiabot_sensor_protobuf_Metadata_Calibration_Cal, jaiabot_sensor_protobuf_Metadata_Calibration_Cal, AUTO)
+PB_BIND(jaiabot_sensor_protobuf_Metadata_Calibration, jaiabot_sensor_protobuf_Metadata_Calibration, AUTO)
 
 
 PB_BIND(jaiabot_sensor_protobuf_Metadata_MetadataValue, jaiabot_sensor_protobuf_Metadata_MetadataValue, AUTO)
 
 
-
-#ifndef PB_CONVERT_DOUBLE_FLOAT
-/* On some platforms (such as AVR), double is really float.
- * To be able to encode/decode double on these platforms, you need.
- * to define PB_CONVERT_DOUBLE_FLOAT in pb.h or compiler command line.
- */
-PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
-#endif
 

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.h
@@ -12,23 +12,19 @@
 #endif
 
 /* Struct definitions */
-typedef struct _jaiabot_sensor_protobuf_Metadata_Calibration_Cal { 
-    char key[16]; 
-    double value; 
-} jaiabot_sensor_protobuf_Metadata_Calibration_Cal;
+typedef struct _jaiabot_sensor_protobuf_Metadata_Calibration { 
+    bool has_time_performed;
+    uint64_t time_performed; 
+    bool has_time_to_recalibrate;
+    uint64_t time_to_recalibrate; 
+    bool has_confirmation;
+    int32_t confirmation; 
+} jaiabot_sensor_protobuf_Metadata_Calibration;
 
 typedef struct _jaiabot_sensor_protobuf_Metadata_MetadataValue { 
     char key[16]; 
     char value[64]; 
 } jaiabot_sensor_protobuf_Metadata_MetadataValue;
-
-typedef struct _jaiabot_sensor_protobuf_Metadata_Calibration { 
-    uint64_t time_performed; 
-    bool has_time_to_recalibrate;
-    uint64_t time_to_recalibrate; 
-    pb_size_t value_count;
-    jaiabot_sensor_protobuf_Metadata_Calibration_Cal value[16]; 
-} jaiabot_sensor_protobuf_Metadata_Calibration;
 
 typedef struct _jaiabot_sensor_protobuf_Metadata { 
     jaiabot_sensor_protobuf_Sensor sensor; 
@@ -53,22 +49,18 @@ extern "C" {
 
 /* Initializer values for message structs */
 #define jaiabot_sensor_protobuf_Metadata_init_default {_jaiabot_sensor_protobuf_Sensor_MIN, false, 0, false, jaiabot_sensor_protobuf_Metadata_Calibration_init_default, false, 0, 0, {jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default}, false, 0, false, 0}
-#define jaiabot_sensor_protobuf_Metadata_Calibration_init_default {0, false, 0, 0, {jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default}}
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_default {"", 0}
+#define jaiabot_sensor_protobuf_Metadata_Calibration_init_default {false, 0, false, 0, false, 0}
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_init_default {"", ""}
 #define jaiabot_sensor_protobuf_Metadata_init_zero {_jaiabot_sensor_protobuf_Sensor_MIN, false, 0, false, jaiabot_sensor_protobuf_Metadata_Calibration_init_zero, false, 0, 0, {jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero, jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero}, false, 0, false, 0}
-#define jaiabot_sensor_protobuf_Metadata_Calibration_init_zero {0, false, 0, 0, {jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero, jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero}}
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_init_zero {"", 0}
+#define jaiabot_sensor_protobuf_Metadata_Calibration_init_zero {false, 0, false, 0, false, 0}
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_init_zero {"", ""}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_key_tag 1
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_value_tag 2
-#define jaiabot_sensor_protobuf_Metadata_MetadataValue_key_tag 1
-#define jaiabot_sensor_protobuf_Metadata_MetadataValue_value_tag 2
 #define jaiabot_sensor_protobuf_Metadata_Calibration_time_performed_tag 1
 #define jaiabot_sensor_protobuf_Metadata_Calibration_time_to_recalibrate_tag 2
-#define jaiabot_sensor_protobuf_Metadata_Calibration_value_tag 3
+#define jaiabot_sensor_protobuf_Metadata_Calibration_confirmation_tag 3
+#define jaiabot_sensor_protobuf_Metadata_MetadataValue_key_tag 1
+#define jaiabot_sensor_protobuf_Metadata_MetadataValue_value_tag 2
 #define jaiabot_sensor_protobuf_Metadata_sensor_tag 1
 #define jaiabot_sensor_protobuf_Metadata_sensor_version_tag 2
 #define jaiabot_sensor_protobuf_Metadata_calibration_tag 3
@@ -92,18 +84,11 @@ X(a, STATIC,   OPTIONAL, BOOL,     init_failed,       7)
 #define jaiabot_sensor_protobuf_Metadata_metadata_MSGTYPE jaiabot_sensor_protobuf_Metadata_MetadataValue
 
 #define jaiabot_sensor_protobuf_Metadata_Calibration_FIELDLIST(X, a) \
-X(a, STATIC,   REQUIRED, UINT64,   time_performed,    1) \
+X(a, STATIC,   OPTIONAL, UINT64,   time_performed,    1) \
 X(a, STATIC,   OPTIONAL, UINT64,   time_to_recalibrate,   2) \
-X(a, STATIC,   REPEATED, MESSAGE,  value,             3)
+X(a, STATIC,   OPTIONAL, INT32,    confirmation,      3)
 #define jaiabot_sensor_protobuf_Metadata_Calibration_CALLBACK NULL
 #define jaiabot_sensor_protobuf_Metadata_Calibration_DEFAULT NULL
-#define jaiabot_sensor_protobuf_Metadata_Calibration_value_MSGTYPE jaiabot_sensor_protobuf_Metadata_Calibration_Cal
-
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_FIELDLIST(X, a) \
-X(a, STATIC,   REQUIRED, STRING,   key,               1) \
-X(a, STATIC,   REQUIRED, DOUBLE,   value,             2)
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_CALLBACK NULL
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_DEFAULT NULL
 
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_FIELDLIST(X, a) \
 X(a, STATIC,   REQUIRED, STRING,   key,               1) \
@@ -113,20 +98,17 @@ X(a, STATIC,   REQUIRED, STRING,   value,             2)
 
 extern const pb_msgdesc_t jaiabot_sensor_protobuf_Metadata_msg;
 extern const pb_msgdesc_t jaiabot_sensor_protobuf_Metadata_Calibration_msg;
-extern const pb_msgdesc_t jaiabot_sensor_protobuf_Metadata_Calibration_Cal_msg;
 extern const pb_msgdesc_t jaiabot_sensor_protobuf_Metadata_MetadataValue_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define jaiabot_sensor_protobuf_Metadata_fields &jaiabot_sensor_protobuf_Metadata_msg
 #define jaiabot_sensor_protobuf_Metadata_Calibration_fields &jaiabot_sensor_protobuf_Metadata_Calibration_msg
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_fields &jaiabot_sensor_protobuf_Metadata_Calibration_Cal_msg
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_fields &jaiabot_sensor_protobuf_Metadata_MetadataValue_msg
 
 /* Maximum encoded size of messages (where known) */
-#define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_size 26
-#define jaiabot_sensor_protobuf_Metadata_Calibration_size 470
+#define jaiabot_sensor_protobuf_Metadata_Calibration_size 33
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_size 82
-#define jaiabot_sensor_protobuf_Metadata_size    1854
+#define jaiabot_sensor_protobuf_Metadata_size    1416
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.pb.h
@@ -41,9 +41,9 @@ typedef struct _jaiabot_sensor_protobuf_Metadata {
     pb_size_t metadata_count;
     jaiabot_sensor_protobuf_Metadata_MetadataValue metadata[16]; 
     bool has_payload_board_version;
-    int32_t payload_board_version;
+    int32_t payload_board_version; 
     bool has_init_failed;
-    bool init_failed;
+    bool init_failed; 
 } jaiabot_sensor_protobuf_Metadata;
 
 
@@ -71,10 +71,10 @@ extern "C" {
 #define jaiabot_sensor_protobuf_Metadata_Calibration_value_tag 3
 #define jaiabot_sensor_protobuf_Metadata_sensor_tag 1
 #define jaiabot_sensor_protobuf_Metadata_sensor_version_tag 2
-#define jaiabot_sensor_protobuf_Metadata_payload_board_version_tag 6
 #define jaiabot_sensor_protobuf_Metadata_calibration_tag 3
 #define jaiabot_sensor_protobuf_Metadata_time_purchased_tag 4
 #define jaiabot_sensor_protobuf_Metadata_metadata_tag 5
+#define jaiabot_sensor_protobuf_Metadata_payload_board_version_tag 6
 #define jaiabot_sensor_protobuf_Metadata_init_failed_tag 7
 
 /* Struct field encoding specification for nanopb */
@@ -123,12 +123,10 @@ extern const pb_msgdesc_t jaiabot_sensor_protobuf_Metadata_MetadataValue_msg;
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_fields &jaiabot_sensor_protobuf_Metadata_MetadataValue_msg
 
 /* Maximum encoded size of messages (where known) */
-#define jaiabot_sensor_protobuf_Metadata_size    1854
-#define jaiabot_sensor_protobuf_Metadata_Calibration_size 470
 #define jaiabot_sensor_protobuf_Metadata_Calibration_Cal_size 26
 #define jaiabot_sensor_protobuf_Metadata_Calibration_size 470
 #define jaiabot_sensor_protobuf_Metadata_MetadataValue_size 82
-#define jaiabot_sensor_protobuf_Metadata_size    1841
+#define jaiabot_sensor_protobuf_Metadata_size    1854
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/metadata.proto
@@ -18,19 +18,14 @@ message Metadata
 
     message Calibration
     {
-        required uint64 time_performed = 1 [(dccl.field) = {
+        optional uint64 time_performed = 1 [(dccl.field) = {
             units { prefix: "micro" derived_dimensions: "time" }
         }];
         optional uint64 time_to_recalibrate = 2 [(dccl.field) = {
             units { prefix: "micro" derived_dimensions: "time" }
         }];
 
-        message Cal
-        {
-            required string key = 1 [(nanopb).max_size = 16];
-            required double value = 2 [(nanopb).max_size = 64];
-        }
-        repeated Cal value = 3  [(nanopb).max_count = 16];
+        optional int32 confirmation = 3;
     }
     optional Calibration calibration = 3;
     optional uint64 time_purchased = 4 [

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
@@ -18,3 +18,11 @@ PB_BIND(jaiabot_sensor_protobuf_SensorThreadConfig, jaiabot_sensor_protobuf_Sens
 
 
 
+#ifndef PB_CONVERT_DOUBLE_FLOAT
+/* On some platforms (such as AVR), double is really float.
+ * To be able to encode/decode double on these platforms, you need.
+ * to define PB_CONVERT_DOUBLE_FLOAT in pb.h or compiler command line.
+ */
+PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
+#endif
+

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
@@ -18,6 +18,7 @@ PB_BIND(jaiabot_sensor_protobuf_SensorThreadConfig, jaiabot_sensor_protobuf_Sens
 
 
 
+
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
  * To be able to encode/decode double on these platforms, you need.

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.c
@@ -17,3 +17,4 @@ PB_BIND(jaiabot_sensor_protobuf_SensorThreadConfig, jaiabot_sensor_protobuf_Sens
 
 
 
+

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
@@ -12,6 +12,7 @@
 #include "jaiabot/messages/sensor/atlas_scientific__oem_ph.pb.h"
 #include "jaiabot/messages/sensor/turner__c_fluor.pb.h"
 #include "jaiabot/messages/sensor/blue_robotics__bar30.pb.h"
+#include "jaiabot/messages/sensor/catalog.pb.h"
 
 #if PB_PROTO_HEADER_VERSION != 40
 #error Regenerate this file with the current version of nanopb generator.
@@ -22,20 +23,20 @@ typedef enum _jaiabot_sensor_protobuf_MCUCommand {
     jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE = 1 
 } jaiabot_sensor_protobuf_MCUCommand;
 
-typedef enum _jaiabot_sensor_protobuf_CalibrationCommand { 
-    jaiabot_sensor_protobuf_CalibrationCommand_START_EC_CALIBRATION = 1, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_DRY = 2, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_LOW = 3, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_HIGH = 4, 
-    jaiabot_sensor_protobuf_CalibrationCommand_START_PH_CALIBRATION = 5, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_LOW = 6, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_MID = 7, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_HIGH = 8, 
-    jaiabot_sensor_protobuf_CalibrationCommand_START_DO_CALIBRATION = 9, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_LOW = 10, 
-    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_HIGH = 11, 
-    jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION = 12 
-} jaiabot_sensor_protobuf_CalibrationCommand;
+typedef enum _jaiabot_sensor_protobuf_CalibrationType { 
+    jaiabot_sensor_protobuf_CalibrationType_START_EC_CALIBRATION = 1, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_DRY = 2, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_LOW = 3, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_HIGH = 4, 
+    jaiabot_sensor_protobuf_CalibrationType_START_DO_CALIBRATION = 5, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_LOW = 6, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH = 7, 
+    jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION = 8, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_LOW = 9, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_MID = 10, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH = 11, 
+    jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION = 12 
+} jaiabot_sensor_protobuf_CalibrationType;
 
 /* Struct definitions */
 typedef struct _jaiabot_sensor_protobuf_SensorData { 
@@ -60,8 +61,8 @@ typedef struct _jaiabot_sensor_protobuf_SensorRequest {
     } request_data; 
     bool has_mcu_command;
     jaiabot_sensor_protobuf_MCUCommand mcu_command; 
-    bool has_calibration_command;
-    jaiabot_sensor_protobuf_CalibrationCommand calibration_command; 
+    bool has_calibration_type;
+    jaiabot_sensor_protobuf_CalibrationType calibration_type; 
 } jaiabot_sensor_protobuf_SensorRequest;
 
 typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig { 
@@ -77,9 +78,9 @@ typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig {
 #define _jaiabot_sensor_protobuf_MCUCommand_MAX jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE
 #define _jaiabot_sensor_protobuf_MCUCommand_ARRAYSIZE ((jaiabot_sensor_protobuf_MCUCommand)(jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE+1))
 
-#define _jaiabot_sensor_protobuf_CalibrationCommand_MIN jaiabot_sensor_protobuf_CalibrationCommand_START_EC_CALIBRATION
-#define _jaiabot_sensor_protobuf_CalibrationCommand_MAX jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION
-#define _jaiabot_sensor_protobuf_CalibrationCommand_ARRAYSIZE ((jaiabot_sensor_protobuf_CalibrationCommand)(jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION+1))
+#define _jaiabot_sensor_protobuf_CalibrationType_MIN jaiabot_sensor_protobuf_CalibrationType_START_EC_CALIBRATION
+#define _jaiabot_sensor_protobuf_CalibrationType_MAX jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION
+#define _jaiabot_sensor_protobuf_CalibrationType_ARRAYSIZE ((jaiabot_sensor_protobuf_CalibrationType)(jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION+1))
 
 
 #ifdef __cplusplus
@@ -87,10 +88,10 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationCommand_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN}
 #define jaiabot_sensor_protobuf_SensorData_init_default {0, 0, {jaiabot_sensor_protobuf_Metadata_init_default}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_default {false, jaiabot_sensor_protobuf_Metadata_init_default, false, 0}
-#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationCommand_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN}
 #define jaiabot_sensor_protobuf_SensorData_init_zero {0, 0, {jaiabot_sensor_protobuf_Metadata_init_zero}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_zero {false, jaiabot_sensor_protobuf_Metadata_init_zero, false, 0}
 
@@ -106,7 +107,7 @@ extern "C" {
 #define jaiabot_sensor_protobuf_SensorRequest_request_metadata_tag 11
 #define jaiabot_sensor_protobuf_SensorRequest_cfg_tag 12
 #define jaiabot_sensor_protobuf_SensorRequest_mcu_command_tag 20
-#define jaiabot_sensor_protobuf_SensorRequest_calibration_command_tag 21
+#define jaiabot_sensor_protobuf_SensorRequest_calibration_type_tag 21
 #define jaiabot_sensor_protobuf_SensorThreadConfig_metadata_tag 1
 #define jaiabot_sensor_protobuf_SensorThreadConfig_sample_rate_tag 2
 
@@ -116,7 +117,7 @@ X(a, STATIC,   REQUIRED, UINT64,   time,              1) \
 X(a, STATIC,   ONEOF,    BOOL,     (request_data,request_metadata,request_data.request_metadata),  11) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (request_data,cfg,request_data.cfg),  12) \
 X(a, STATIC,   OPTIONAL, UENUM,    mcu_command,      20) \
-X(a, STATIC,   OPTIONAL, UENUM,    calibration_command,  21)
+X(a, STATIC,   OPTIONAL, UENUM,    calibration_type,  21)
 #define jaiabot_sensor_protobuf_SensorRequest_CALLBACK NULL
 #define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\xa8\x01\x01\x00"
 #define jaiabot_sensor_protobuf_SensorRequest_request_data_cfg_MSGTYPE jaiabot_sensor_protobuf_Configuration

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
@@ -22,6 +22,21 @@ typedef enum _jaiabot_sensor_protobuf_MCUCommand {
     jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE = 1 
 } jaiabot_sensor_protobuf_MCUCommand;
 
+typedef enum _jaiabot_sensor_protobuf_CalibrationCommand { 
+    jaiabot_sensor_protobuf_CalibrationCommand_START_EC_CALIBRATION = 1, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_DRY = 2, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_LOW = 3, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_EC_HIGH = 4, 
+    jaiabot_sensor_protobuf_CalibrationCommand_START_PH_CALIBRATION = 5, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_LOW = 6, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_MID = 7, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_PH_HIGH = 8, 
+    jaiabot_sensor_protobuf_CalibrationCommand_START_DO_CALIBRATION = 9, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_LOW = 10, 
+    jaiabot_sensor_protobuf_CalibrationCommand_CALIBRATE_DO_HIGH = 11, 
+    jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION = 12 
+} jaiabot_sensor_protobuf_CalibrationCommand;
+
 /* Struct definitions */
 typedef struct _jaiabot_sensor_protobuf_SensorData { 
     uint64_t time; 
@@ -45,6 +60,8 @@ typedef struct _jaiabot_sensor_protobuf_SensorRequest {
     } request_data; 
     bool has_mcu_command;
     jaiabot_sensor_protobuf_MCUCommand mcu_command; 
+    bool has_calibration_command;
+    jaiabot_sensor_protobuf_CalibrationCommand calibration_command; 
 } jaiabot_sensor_protobuf_SensorRequest;
 
 typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig { 
@@ -60,16 +77,20 @@ typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig {
 #define _jaiabot_sensor_protobuf_MCUCommand_MAX jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE
 #define _jaiabot_sensor_protobuf_MCUCommand_ARRAYSIZE ((jaiabot_sensor_protobuf_MCUCommand)(jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE+1))
 
+#define _jaiabot_sensor_protobuf_CalibrationCommand_MIN jaiabot_sensor_protobuf_CalibrationCommand_START_EC_CALIBRATION
+#define _jaiabot_sensor_protobuf_CalibrationCommand_MAX jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION
+#define _jaiabot_sensor_protobuf_CalibrationCommand_ARRAYSIZE ((jaiabot_sensor_protobuf_CalibrationCommand)(jaiabot_sensor_protobuf_CalibrationCommand_STOP_CALIBRATION+1))
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationCommand_MIN}
 #define jaiabot_sensor_protobuf_SensorData_init_default {0, 0, {jaiabot_sensor_protobuf_Metadata_init_default}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_default {false, jaiabot_sensor_protobuf_Metadata_init_default, false, 0}
-#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationCommand_MIN}
 #define jaiabot_sensor_protobuf_SensorData_init_zero {0, 0, {jaiabot_sensor_protobuf_Metadata_init_zero}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_zero {false, jaiabot_sensor_protobuf_Metadata_init_zero, false, 0}
 
@@ -85,6 +106,7 @@ extern "C" {
 #define jaiabot_sensor_protobuf_SensorRequest_request_metadata_tag 11
 #define jaiabot_sensor_protobuf_SensorRequest_cfg_tag 12
 #define jaiabot_sensor_protobuf_SensorRequest_mcu_command_tag 20
+#define jaiabot_sensor_protobuf_SensorRequest_calibration_command_tag 21
 #define jaiabot_sensor_protobuf_SensorThreadConfig_metadata_tag 1
 #define jaiabot_sensor_protobuf_SensorThreadConfig_sample_rate_tag 2
 
@@ -93,9 +115,10 @@ extern "C" {
 X(a, STATIC,   REQUIRED, UINT64,   time,              1) \
 X(a, STATIC,   ONEOF,    BOOL,     (request_data,request_metadata,request_data.request_metadata),  11) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (request_data,cfg,request_data.cfg),  12) \
-X(a, STATIC,   OPTIONAL, UENUM,    mcu_command,      20)
+X(a, STATIC,   OPTIONAL, UENUM,    mcu_command,      20) \
+X(a, STATIC,   OPTIONAL, UENUM,    calibration_command,  21)
 #define jaiabot_sensor_protobuf_SensorRequest_CALLBACK NULL
-#define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\x00"
+#define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\xa8\x01\x01\x00"
 #define jaiabot_sensor_protobuf_SensorRequest_request_data_cfg_MSGTYPE jaiabot_sensor_protobuf_Configuration
 
 #define jaiabot_sensor_protobuf_SensorData_FIELDLIST(X, a) \
@@ -132,9 +155,9 @@ extern const pb_msgdesc_t jaiabot_sensor_protobuf_SensorThreadConfig_msg;
 #define jaiabot_sensor_protobuf_SensorThreadConfig_fields &jaiabot_sensor_protobuf_SensorThreadConfig_msg
 
 /* Maximum encoded size of messages (where known) */
-#define jaiabot_sensor_protobuf_SensorData_size  1855
-#define jaiabot_sensor_protobuf_SensorRequest_size 1372
-#define jaiabot_sensor_protobuf_SensorThreadConfig_size 1855
+#define jaiabot_sensor_protobuf_SensorData_size  1868
+#define jaiabot_sensor_protobuf_SensorRequest_size 1375
+#define jaiabot_sensor_protobuf_SensorThreadConfig_size 1868
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
@@ -23,19 +23,30 @@ typedef enum _jaiabot_sensor_protobuf_MCUCommand {
     jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE = 1 
 } jaiabot_sensor_protobuf_MCUCommand;
 
+typedef enum _jaiabot_sensor_protobuf_CompensationType { 
+    jaiabot_sensor_protobuf_CompensationType_SET_EC_TEMPERATURE_COMPENSATION = 1, 
+    jaiabot_sensor_protobuf_CompensationType_SET_DO_SALINITY_COMPENSATION = 2, 
+    jaiabot_sensor_protobuf_CompensationType_SET_DO_PRESSURE_COMPENSATION = 3, 
+    jaiabot_sensor_protobuf_CompensationType_SET_DO_TEMPERATURE_COMPENSATION = 4, 
+    jaiabot_sensor_protobuf_CompensationType_SET_PH_TEMPERATURE_COMPENSATION = 5 
+} jaiabot_sensor_protobuf_CompensationType;
+
 typedef enum _jaiabot_sensor_protobuf_CalibrationType { 
     jaiabot_sensor_protobuf_CalibrationType_START_EC_CALIBRATION = 1, 
     jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_DRY = 2, 
     jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_LOW = 3, 
     jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_EC_HIGH = 4, 
-    jaiabot_sensor_protobuf_CalibrationType_START_DO_CALIBRATION = 5, 
-    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_LOW = 6, 
-    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH = 7, 
-    jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION = 8, 
-    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_LOW = 9, 
-    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_MID = 10, 
-    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH = 11, 
-    jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION = 12 
+    jaiabot_sensor_protobuf_CalibrationType_CLEAR_EC_CALIBRATION = 5, 
+    jaiabot_sensor_protobuf_CalibrationType_START_DO_CALIBRATION = 6, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_LOW = 7, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_DO_HIGH = 8, 
+    jaiabot_sensor_protobuf_CalibrationType_CLEAR_DO_CALIBRATION = 9, 
+    jaiabot_sensor_protobuf_CalibrationType_START_PH_CALIBRATION = 10, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_LOW = 11, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_MID = 12, 
+    jaiabot_sensor_protobuf_CalibrationType_CALIBRATE_PH_HIGH = 13, 
+    jaiabot_sensor_protobuf_CalibrationType_CLEAR_PH_CALIBRATION = 14, 
+    jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION = 15 /* stop calibration and return to normal operation */
 } jaiabot_sensor_protobuf_CalibrationType;
 
 /* Struct definitions */
@@ -65,6 +76,10 @@ typedef struct _jaiabot_sensor_protobuf_SensorRequest {
     jaiabot_sensor_protobuf_CalibrationType calibration_type; 
     bool has_calibration_value;
     double calibration_value; 
+    bool has_compensation_type;
+    jaiabot_sensor_protobuf_CompensationType compensation_type; 
+    bool has_compensation_value;
+    double compensation_value; 
 } jaiabot_sensor_protobuf_SensorRequest;
 
 typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig { 
@@ -80,6 +95,10 @@ typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig {
 #define _jaiabot_sensor_protobuf_MCUCommand_MAX jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE
 #define _jaiabot_sensor_protobuf_MCUCommand_ARRAYSIZE ((jaiabot_sensor_protobuf_MCUCommand)(jaiabot_sensor_protobuf_MCUCommand_ENTER_BOOTLOADER_MODE+1))
 
+#define _jaiabot_sensor_protobuf_CompensationType_MIN jaiabot_sensor_protobuf_CompensationType_SET_EC_TEMPERATURE_COMPENSATION
+#define _jaiabot_sensor_protobuf_CompensationType_MAX jaiabot_sensor_protobuf_CompensationType_SET_PH_TEMPERATURE_COMPENSATION
+#define _jaiabot_sensor_protobuf_CompensationType_ARRAYSIZE ((jaiabot_sensor_protobuf_CompensationType)(jaiabot_sensor_protobuf_CompensationType_SET_PH_TEMPERATURE_COMPENSATION+1))
+
 #define _jaiabot_sensor_protobuf_CalibrationType_MIN jaiabot_sensor_protobuf_CalibrationType_START_EC_CALIBRATION
 #define _jaiabot_sensor_protobuf_CalibrationType_MAX jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION
 #define _jaiabot_sensor_protobuf_CalibrationType_ARRAYSIZE ((jaiabot_sensor_protobuf_CalibrationType)(jaiabot_sensor_protobuf_CalibrationType_STOP_CALIBRATION+1))
@@ -90,10 +109,10 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0}
+#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0, false, _jaiabot_sensor_protobuf_CompensationType_MIN, false, 0}
 #define jaiabot_sensor_protobuf_SensorData_init_default {0, 0, {jaiabot_sensor_protobuf_Metadata_init_default}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_default {false, jaiabot_sensor_protobuf_Metadata_init_default, false, 0}
-#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0}
+#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0, false, _jaiabot_sensor_protobuf_CompensationType_MIN, false, 0}
 #define jaiabot_sensor_protobuf_SensorData_init_zero {0, 0, {jaiabot_sensor_protobuf_Metadata_init_zero}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_zero {false, jaiabot_sensor_protobuf_Metadata_init_zero, false, 0}
 
@@ -111,6 +130,8 @@ extern "C" {
 #define jaiabot_sensor_protobuf_SensorRequest_mcu_command_tag 20
 #define jaiabot_sensor_protobuf_SensorRequest_calibration_type_tag 21
 #define jaiabot_sensor_protobuf_SensorRequest_calibration_value_tag 22
+#define jaiabot_sensor_protobuf_SensorRequest_compensation_type_tag 23
+#define jaiabot_sensor_protobuf_SensorRequest_compensation_value_tag 24
 #define jaiabot_sensor_protobuf_SensorThreadConfig_metadata_tag 1
 #define jaiabot_sensor_protobuf_SensorThreadConfig_sample_rate_tag 2
 
@@ -121,9 +142,11 @@ X(a, STATIC,   ONEOF,    BOOL,     (request_data,request_metadata,request_data.r
 X(a, STATIC,   ONEOF,    MESSAGE,  (request_data,cfg,request_data.cfg),  12) \
 X(a, STATIC,   OPTIONAL, UENUM,    mcu_command,      20) \
 X(a, STATIC,   OPTIONAL, UENUM,    calibration_type,  21) \
-X(a, STATIC,   OPTIONAL, DOUBLE,   calibration_value,  22)
+X(a, STATIC,   OPTIONAL, DOUBLE,   calibration_value,  22) \
+X(a, STATIC,   OPTIONAL, UENUM,    compensation_type,  23) \
+X(a, STATIC,   OPTIONAL, DOUBLE,   compensation_value,  24)
 #define jaiabot_sensor_protobuf_SensorRequest_CALLBACK NULL
-#define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\xa8\x01\x01\x00"
+#define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\xa8\x01\x01\xb8\x01\x01\x00"
 #define jaiabot_sensor_protobuf_SensorRequest_request_data_cfg_MSGTYPE jaiabot_sensor_protobuf_Configuration
 
 #define jaiabot_sensor_protobuf_SensorData_FIELDLIST(X, a) \
@@ -161,7 +184,7 @@ extern const pb_msgdesc_t jaiabot_sensor_protobuf_SensorThreadConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define jaiabot_sensor_protobuf_SensorData_size  1868
-#define jaiabot_sensor_protobuf_SensorRequest_size 1385
+#define jaiabot_sensor_protobuf_SensorRequest_size 1398
 #define jaiabot_sensor_protobuf_SensorThreadConfig_size 1868
 
 #ifdef __cplusplus

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.pb.h
@@ -63,6 +63,8 @@ typedef struct _jaiabot_sensor_protobuf_SensorRequest {
     jaiabot_sensor_protobuf_MCUCommand mcu_command; 
     bool has_calibration_type;
     jaiabot_sensor_protobuf_CalibrationType calibration_type; 
+    bool has_calibration_value;
+    double calibration_value; 
 } jaiabot_sensor_protobuf_SensorRequest;
 
 typedef struct _jaiabot_sensor_protobuf_SensorThreadConfig { 
@@ -88,10 +90,10 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_default {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0}
 #define jaiabot_sensor_protobuf_SensorData_init_default {0, 0, {jaiabot_sensor_protobuf_Metadata_init_default}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_default {false, jaiabot_sensor_protobuf_Metadata_init_default, false, 0}
-#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN}
+#define jaiabot_sensor_protobuf_SensorRequest_init_zero {0, 0, {0}, false, _jaiabot_sensor_protobuf_MCUCommand_MIN, false, _jaiabot_sensor_protobuf_CalibrationType_MIN, false, 0}
 #define jaiabot_sensor_protobuf_SensorData_init_zero {0, 0, {jaiabot_sensor_protobuf_Metadata_init_zero}}
 #define jaiabot_sensor_protobuf_SensorThreadConfig_init_zero {false, jaiabot_sensor_protobuf_Metadata_init_zero, false, 0}
 
@@ -108,6 +110,7 @@ extern "C" {
 #define jaiabot_sensor_protobuf_SensorRequest_cfg_tag 12
 #define jaiabot_sensor_protobuf_SensorRequest_mcu_command_tag 20
 #define jaiabot_sensor_protobuf_SensorRequest_calibration_type_tag 21
+#define jaiabot_sensor_protobuf_SensorRequest_calibration_value_tag 22
 #define jaiabot_sensor_protobuf_SensorThreadConfig_metadata_tag 1
 #define jaiabot_sensor_protobuf_SensorThreadConfig_sample_rate_tag 2
 
@@ -117,7 +120,8 @@ X(a, STATIC,   REQUIRED, UINT64,   time,              1) \
 X(a, STATIC,   ONEOF,    BOOL,     (request_data,request_metadata,request_data.request_metadata),  11) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (request_data,cfg,request_data.cfg),  12) \
 X(a, STATIC,   OPTIONAL, UENUM,    mcu_command,      20) \
-X(a, STATIC,   OPTIONAL, UENUM,    calibration_type,  21)
+X(a, STATIC,   OPTIONAL, UENUM,    calibration_type,  21) \
+X(a, STATIC,   OPTIONAL, DOUBLE,   calibration_value,  22)
 #define jaiabot_sensor_protobuf_SensorRequest_CALLBACK NULL
 #define jaiabot_sensor_protobuf_SensorRequest_DEFAULT (const pb_byte_t*)"\xa0\x01\x01\xa8\x01\x01\x00"
 #define jaiabot_sensor_protobuf_SensorRequest_request_data_cfg_MSGTYPE jaiabot_sensor_protobuf_Configuration
@@ -157,7 +161,7 @@ extern const pb_msgdesc_t jaiabot_sensor_protobuf_SensorThreadConfig_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define jaiabot_sensor_protobuf_SensorData_size  1868
-#define jaiabot_sensor_protobuf_SensorRequest_size 1375
+#define jaiabot_sensor_protobuf_SensorRequest_size 1385
 #define jaiabot_sensor_protobuf_SensorThreadConfig_size 1868
 
 #ifdef __cplusplus

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
@@ -8,6 +8,7 @@ import "jaiabot/messages/sensor/atlas_scientific__oem_do.proto";
 import "jaiabot/messages/sensor/atlas_scientific__oem_ph.proto";
 import "jaiabot/messages/sensor/turner__c_fluor.proto";
 import "jaiabot/messages/sensor/blue_robotics__bar30.proto";
+import "jaiabot/messages/sensor/catalog.proto";
 
 package jaiabot.sensor.protobuf;
 
@@ -16,20 +17,20 @@ enum MCUCommand
     ENTER_BOOTLOADER_MODE = 1;
 }
 
-enum CalibrationCommand
+enum CalibrationType
 {
     START_EC_CALIBRATION = 1;
     CALIBRATE_EC_DRY = 2;
     CALIBRATE_EC_LOW = 3;
     CALIBRATE_EC_HIGH = 4;
-    START_PH_CALIBRATION = 5;
-    CALIBRATE_PH_LOW = 6;
-    CALIBRATE_PH_MID = 7;
-    CALIBRATE_PH_HIGH = 8;
-    START_DO_CALIBRATION = 9;
-    CALIBRATE_DO_LOW = 10;
-    CALIBRATE_DO_HIGH = 11;
-    STOP_CALIBRATION = 12;
+    START_DO_CALIBRATION = 5;
+    CALIBRATE_DO_LOW = 6;
+    CALIBRATE_DO_HIGH = 7;
+    START_PH_CALIBRATION = 8;
+    CALIBRATE_PH_LOW = 9;
+    CALIBRATE_PH_MID = 10;
+    CALIBRATE_PH_HIGH = 11;
+    STOP_CALIBRATION = 12; 
 }
 
 message SensorRequest
@@ -52,7 +53,7 @@ message SensorRequest
     }
 
     optional MCUCommand mcu_command = 20;
-    optional CalibrationCommand calibration_command = 21;
+    optional CalibrationType calibration_type = 21;
 }
 
 message SensorData

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
@@ -17,20 +17,32 @@ enum MCUCommand
     ENTER_BOOTLOADER_MODE = 1;
 }
 
+enum CompensationType
+{
+    SET_EC_TEMPERATURE_COMPENSATION = 1;
+    SET_DO_SALINITY_COMPENSATION = 2;
+    SET_DO_PRESSURE_COMPENSATION = 3;
+    SET_DO_TEMPERATURE_COMPENSATION = 4;
+    SET_PH_TEMPERATURE_COMPENSATION = 5;
+}
+
 enum CalibrationType
 {
     START_EC_CALIBRATION = 1;
     CALIBRATE_EC_DRY = 2;
     CALIBRATE_EC_LOW = 3;
     CALIBRATE_EC_HIGH = 4;
-    START_DO_CALIBRATION = 5;
-    CALIBRATE_DO_LOW = 6;
-    CALIBRATE_DO_HIGH = 7;
-    START_PH_CALIBRATION = 8;
-    CALIBRATE_PH_LOW = 9;
-    CALIBRATE_PH_MID = 10;
-    CALIBRATE_PH_HIGH = 11;
-    STOP_CALIBRATION = 12; 
+    CLEAR_EC_CALIBRATION = 5;
+    START_DO_CALIBRATION = 6;
+    CALIBRATE_DO_LOW = 7;
+    CALIBRATE_DO_HIGH = 8;
+    CLEAR_DO_CALIBRATION = 9;   
+    START_PH_CALIBRATION = 10;
+    CALIBRATE_PH_LOW = 11;
+    CALIBRATE_PH_MID = 12;
+    CALIBRATE_PH_HIGH = 13;
+    CLEAR_PH_CALIBRATION = 14;
+    STOP_CALIBRATION = 15; // stop calibration and return to normal operation
 }
 
 message SensorRequest
@@ -55,6 +67,8 @@ message SensorRequest
     optional MCUCommand mcu_command = 20;
     optional CalibrationType calibration_type = 21;
     optional double calibration_value = 22;
+    optional CompensationType compensation_type = 23;
+    optional double compensation_value = 24;
 }
 
 message SensorData

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
@@ -54,6 +54,7 @@ message SensorRequest
 
     optional MCUCommand mcu_command = 20;
     optional CalibrationType calibration_type = 21;
+    optional double calibration_value = 22;
 }
 
 message SensorData

--- a/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
+++ b/JAIA_BIO-PAYLOAD/Core/nanopb/jaiabot/messages/sensor/sensor_core.proto
@@ -16,6 +16,22 @@ enum MCUCommand
     ENTER_BOOTLOADER_MODE = 1;
 }
 
+enum CalibrationCommand
+{
+    START_EC_CALIBRATION = 1;
+    CALIBRATE_EC_DRY = 2;
+    CALIBRATE_EC_LOW = 3;
+    CALIBRATE_EC_HIGH = 4;
+    START_PH_CALIBRATION = 5;
+    CALIBRATE_PH_LOW = 6;
+    CALIBRATE_PH_MID = 7;
+    CALIBRATE_PH_HIGH = 8;
+    START_DO_CALIBRATION = 9;
+    CALIBRATE_DO_LOW = 10;
+    CALIBRATE_DO_HIGH = 11;
+    STOP_CALIBRATION = 12;
+}
+
 message SensorRequest
 {
     option (dccl.msg) = {
@@ -36,6 +52,7 @@ message SensorRequest
     }
 
     optional MCUCommand mcu_command = 20;
+    optional CalibrationCommand calibration_command = 21;
 }
 
 message SensorData


### PR DESCRIPTION
Gives the ability to send calibration/compensation commands to the Atlas Scientific EC, DO, and pH chips via Liaison.

To conduct a calibration:

Navigate to the bot's Liaison page
Go to Commander
In the "Message" dropdown, select jaiabot.sensor.protobuf.SensorRequest
Include a comment in the "Log comment" field
Include an integer in the "time" field
In the "calibration_type" dropdown, select "START_xx_CALIBRATION" to stop the data from being sent from all other Atlas chips, and update the current sensor to report at 1Hz
Press send
Under "calibration_type", select the type of calibration you'd like to perform. Include the value to calibrate to in the "calibration_value" field.
Press send
Once all calibrations have been set for a chip, select "STOP_CALIBRATION" under the "calibration_type" field.
To set a compensation value, perform the same steps above under the "compensation_type" and "compensation_value" fields.
The BIO payload board will return the calibration confirmation of each chip when a calibration command is sent. These confirmation values can be verified against the datasheet for each OEM Atlas chip.

Must be deployed in conjunction with https://github.com/jaiarobotics/jaiabot/pull/1168